### PR TITLE
fix: wait between portal connection retries

### DIFF
--- a/microsandbox-server/lib/handler.rs
+++ b/microsandbox-server/lib/handler.rs
@@ -259,8 +259,9 @@ pub async fn forward_rpc_to_portal(
     let client = reqwest::Client::new();
 
     // Configure connection retry parameters
-    const MAX_RETRIES: u32 = 10_000;
+    const MAX_RETRIES: u32 = 200;
     const TIMEOUT_MS: u64 = 50;
+    const RETRY_DELAY_MS: u64 = 50;
 
     // Try to establish a connection to the portal before sending the actual request
     let mut retry_count = 0;
@@ -288,6 +289,7 @@ pub async fn forward_rpc_to_portal(
                 // Track the error for potential reporting but keep retrying
                 last_error = Some(e);
                 trace!("Connection attempt {} failed, retrying...", retry_count + 1);
+                sleep(Duration::from_millis(RETRY_DELAY_MS)).await;
             }
         }
 


### PR DESCRIPTION
## Summary
- add small delay between portal connection retries and reduce retry count

## Testing
- `cargo test -p microsandbox-server` *(fails: cannot find -lkrun)*

------
https://chatgpt.com/codex/tasks/task_e_68bef5b8e068833297780f49710d51bf